### PR TITLE
Update clicklistener to TaskRecycleAdapter

### DIFF
--- a/app/src/main/java/com/pixellore/checklist/AdapterUtility/TaskRecycleAdapter.kt
+++ b/app/src/main/java/com/pixellore/checklist/AdapterUtility/TaskRecycleAdapter.kt
@@ -19,6 +19,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.pixellore.checklist.DatabaseUtility.*
 import com.pixellore.checklist.MainActivity
 import com.pixellore.checklist.R
+import com.pixellore.checklist.utils.Constants
 import com.pixellore.checklist.utils.SpaceDecorator
 
 /**
@@ -26,7 +27,7 @@ import com.pixellore.checklist.utils.SpaceDecorator
  *
 * */
 
-class TaskRecycleAdapter(private val clickListener: (position: Int, task:Task) -> Unit,
+class TaskRecycleAdapter(private val clickListener: (position: Int, taskWithSubtasks:TaskWithSubtasks, actionRequested:Int) -> Unit,
                          private val clickListenerSubtask: (position: Int, subtask: Subtask) -> Unit):
     ListAdapter<TaskWithSubtasks, TaskRecycleAdapter.TaskRecycleViewHolder>(ActionItemComparator()) {
 
@@ -50,7 +51,7 @@ class TaskRecycleAdapter(private val clickListener: (position: Int, task:Task) -
 
 
         fun bind(currentTask: TaskWithSubtasks, context: Context,
-                 clickListener: (position: Int, task: Task) -> Unit,
+                 clickListener: (position: Int, taskWithSubtasks: TaskWithSubtasks, actionRequested:Int) -> Unit,
                  clickListenerSubtask: (position: Int, subtask: Subtask) -> Unit)
         {
 
@@ -97,7 +98,7 @@ class TaskRecycleAdapter(private val clickListener: (position: Int, task:Task) -
                     currentTask.task.isExpanded = !currentTask.task.isExpanded
                     toggleSubtasksDisplay(currentTask, subLayout)
                     // Update in database
-                    clickListener(adapterPosition, currentTask.task)
+                    clickListener(adapterPosition, currentTask, Constants.UPDATE_DB)
                 }
 
 
@@ -109,7 +110,14 @@ class TaskRecycleAdapter(private val clickListener: (position: Int, task:Task) -
                     currentTask.task.task_isCompleted = isChecked
                     toggleStrikeThrough(textViewToStrike = taskTitleView, isChecked)
                     // Update in database
-                    clickListener(adapterPosition, currentTask.task)
+                    clickListener(adapterPosition, currentTask, Constants.UPDATE_DB)
+                }
+
+                /**
+                 * Open the item for editing
+                 * */
+                taskCardLayout.setOnClickListener {
+                    clickListener(adapterPosition, currentTask, Constants.OPEN_EDITOR)
                 }
 
             }

--- a/app/src/main/java/com/pixellore/checklist/MainActivity.kt
+++ b/app/src/main/java/com/pixellore/checklist/MainActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.graphics.Color
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.provider.SyncStateContract
 import android.util.Log
 import android.view.Menu
 import android.view.MenuInflater
@@ -19,6 +20,7 @@ import androidx.recyclerview.widget.SimpleItemAnimator
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.pixellore.checklist.AdapterUtility.TaskRecycleAdapter
 import com.pixellore.checklist.DatabaseUtility.*
+import com.pixellore.checklist.utils.Constants
 
 class MainActivity : AppCompatActivity() {
 
@@ -91,7 +93,7 @@ class MainActivity : AppCompatActivity() {
 
 
         val adapter = TaskRecycleAdapter(
-            {position, task ->  onListItemClick(position, task)},
+            {position, taskWithSubtasks, actionRequested ->  onListItemClick(position, taskWithSubtasks, actionRequested)},
             {position, subtask ->  onListSubtaskClick(position, subtask)})
 
 
@@ -148,10 +150,16 @@ class MainActivity : AppCompatActivity() {
      *
      * This function is passed as an argument to the recycler view adapter
      * */
-    private fun onListItemClick(position: Int, task:Task) {
+    private fun onListItemClick(position: Int, taskWithSubtasks:TaskWithSubtasks, actionRequested: Int ) {
         //Toast.makeText(applicationContext, position.toString(), Toast.LENGTH_SHORT).show()
 
-        actionPlanViewModel.update(task)
+        if (actionRequested == Constants.UPDATE_DB){
+            actionPlanViewModel.update(taskWithSubtasks.task)
+        } else if (actionRequested == Constants.OPEN_EDITOR){
+            // todo
+        }
+
+
     }
 
 

--- a/app/src/main/java/com/pixellore/checklist/utils/Constants.kt
+++ b/app/src/main/java/com/pixellore/checklist/utils/Constants.kt
@@ -1,0 +1,10 @@
+package com.pixellore.checklist.utils
+
+object Constants{
+
+    const val UPDATE_DB = 1
+    const val OPEN_EDITOR = 2
+
+    //const val TAG = "Debug"
+
+}


### PR DESCRIPTION
Parameters of the click listener changed so that the when a task is clicked it can be opened in the task editor with its details like name, due date and subtasks already filled in the task editor.

![image](https://user-images.githubusercontent.com/15008191/213931076-1b4039fa-df88-4293-a0cb-285d00049664.png)
